### PR TITLE
Upgrade deprecated gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules/
 *.gem
 
 /Gemfile.lock
+.DS_Store

--- a/lib/pugin/engine.rb
+++ b/lib/pugin/engine.rb
@@ -9,7 +9,7 @@ module Pugin
 
     config.generators do |g|
       g.test_framework :rspec, fixture: false
-      g.fixture_replacement :factory_girl, dir: 'spec/factories'
+      g.fixture_replacement :factory_bot, dir: 'spec/factories'
       g.assets false
       g.helper false
     end

--- a/pugin.gemspec
+++ b/pugin.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sqlite3', '~> 1.3'
   s.add_development_dependency 'rspec-rails', '~> 3.6'
   s.add_development_dependency 'capybara', '~> 2.15'
-  s.add_development_dependency 'factory_girl_rails', '~> 4.8'
+  s.add_development_dependency 'factory_bot_rails', '~> 4.8'
   s.add_development_dependency 'simplecov', '~> 0.12'
   s.add_development_dependency 'coveralls', '~> 0.8'
   s.add_development_dependency 'rubocop', '~> 0.50'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ require 'bandiera/client'
 
 require File.expand_path('../dummy/config/environment.rb', __FILE__)
 require 'rspec/rails'
-require 'factory_girl_rails'
+require 'factory_bot_rails'
 
 Rails.backtrace_cleaner.remove_silencers!
 


### PR DESCRIPTION
`factory_girl_rails` has been deprecated in favour of a rename to `factory_bot`, so this gets rid of the deprecation warning when running rspec